### PR TITLE
Add numpy to CI main tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest requests
+          pip install flake8 pytest requests numpy
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Lint with flake8
         run: |


### PR DESCRIPTION
Hey, should we potentially add numpy to the requirements? It is used for the distance matrices and the CI tests keep failing, because it is not installed.